### PR TITLE
Fix segfaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@port-labs/jq-node-bindings",
-  "version": "v1.0.3",
+  "version": "v1.0.4",
   "description": "Node.js bindings for JQ",
   "jq-node-bindings": "1.0.3",
   "main": "lib/index.js",

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -359,17 +359,6 @@ bool jv_object_to_napi(std::string key, napi_env env, jv actual, napi_value ret,
     return true;
 }
 
-static jv custom_input_cb(jq_state *jq, void *data) {
-    jv *input_ptr = (jv*)data;
-    if (jv_is_valid(*input_ptr)) {
-        jv ret = jv_copy(*input_ptr);
-        jv_free(*input_ptr);
-        *input_ptr = jv_null();
-        return ret;
-    }
-    return jv_invalid();
-}
-
 napi_value ExecSync(napi_env env, napi_callback_info info) {
     size_t argc = 2;
     napi_value args[2];
@@ -425,7 +414,7 @@ napi_value ExecSync(napi_env env, napi_callback_info info) {
     }
 
     wrapper->lock();
-    jq_set_input_cb(wrapper->get_jq(), custom_input_cb, &input);
+    jq_set_input_cb(wrapper->get_jq(), NULL, NULL);
 
     jq_start(wrapper->get_jq(), input, 0);
     jv result = jq_next(wrapper->get_jq(), global_timeout_sec);
@@ -500,7 +489,7 @@ void ExecuteAsync(napi_env env, void* data) {
         return;
     }
     wrapper->lock();
-    jq_set_input_cb(wrapper->get_jq(), custom_input_cb, &input);
+    jq_set_input_cb(wrapper->get_jq(), NULL, NULL);
     jq_start(wrapper->get_jq(), input, 0);
     ASYNC_DEBUG_LOG(work, "jq execution started");
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -359,7 +359,7 @@ bool jv_object_to_napi(std::string key, napi_env env, jv actual, napi_value ret,
     return true;
 }
 
-static jv jq_input_cb(jq_state *jq, void *data) {
+static jv custom_input_cb(jq_state *jq, void *data) {
     jv *input_ptr = (jv*)data;
     if (jv_is_valid(*input_ptr)) {
         jv ret = jv_copy(*input_ptr);
@@ -369,7 +369,6 @@ static jv jq_input_cb(jq_state *jq, void *data) {
     }
     return jv_invalid();
 }
-
 
 napi_value ExecSync(napi_env env, napi_callback_info info) {
     size_t argc = 2;
@@ -426,7 +425,7 @@ napi_value ExecSync(napi_env env, napi_callback_info info) {
     }
 
     wrapper->lock();
-    jq_set_input_cb(wrapper->get_jq(), jq_input_cb, &input);
+    jq_set_input_cb(wrapper->get_jq(), custom_input_cb, &input);
 
     jq_start(wrapper->get_jq(), input, 0);
     jv result = jq_next(wrapper->get_jq(), global_timeout_sec);
@@ -501,7 +500,7 @@ void ExecuteAsync(napi_env env, void* data) {
         return;
     }
     wrapper->lock();
-    jq_set_input_cb(wrapper->get_jq(), jq_input_cb, &input);
+    jq_set_input_cb(wrapper->get_jq(), custom_input_cb, &input);
     jq_start(wrapper->get_jq(), input, 0);
     ASYNC_DEBUG_LOG(work, "jq execution started");
 


### PR DESCRIPTION
Reproduce can be done via the following JSON input:
```json
	const input = {
		test: '{{ inputs.xy }}',
	};
```
When teh filter refers to something like inputs.yx, it triggers a call to one of the built‐in functions—specifically the `input` built‐in. In the global function table, the entry for `input` is set to point to the C function f_input. So, when the interpreter reaches the CALL_BUILTIN opcode for `input`, it dispatches the call to f_input which causes SEG FAULT.
If the input callback isn’t properly set up (for example, via a function like jq_set_cb or a similar initialization), then when f_input is invoked that's something that might happen - although I am not yet sure why it reproduces only on Linux and not on MacOS

Builtin table map from `builtin.c`
``` 
  {f_input, "input", 1},
```

JQ Trace logs:
```
[DEBUG] jq_next
0000 TOP
0001 DUP        {}
0002 PUSHK_UNDER {}     {} || {}
0004 POP        {} || {} || {}
0005 STOREV $ENV:0      {} || {}
V0 = {} (2)
0008 PUSHK_UNDER "x_y"      {}
0010 CALL_JQ inputs:3   {} || "x_y" (2)
0000 FORK_OPT 0010       || "x_y" (2)
0002 CALL_JQ repeat:2^1 @lambda:0       {} || "x_y" (2)
0000 CALL_JQ _repeat:0  {} || "x_y" (2)
0000 FORK 0008   || "x_y" (2)
0002 TAIL_CALL_JQ exp:0^1       {} || "x_y" (2)
0000 CALL_BUILTIN _input        {} || "x_y" (2)

Thread 1 "node" received signal SIGSEGV, Segmentation fault.
0x00007ffff4e60806 in f_input () from /home/daniel/Port/node_modules/@port-labs/jq-node-bindings/build/Release/../deps/libjq.so.1
(gdb)
```