### PR TITLE
chore: update GitHub Actions workflow for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,26 +4,25 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
       - name: Install node-gyp deps
         run: sudo apt-get install -y autoconf make libtool automake
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
+          node-version: 22
           cache: "npm"
       - run: npm ci
-      - run: npm publish --access=public --tag=next
+      - run: npm publish --provenance --tag=next
         if: ${{ github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-      - run: npm publish --access=public
+      - run: npm publish --provenance
         if: ${{ !github.event.release.prerelease }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
- Upgrade actions/checkout from v3 to v4
- Upgrade actions/setup-node from v3 to v4 and change node version to 22
- Modify npm publish commands to include --provenance flag
- Adjust permissions for id-token and contents